### PR TITLE
Remove extra space

### DIFF
--- a/scripts/template.html
+++ b/scripts/template.html
@@ -21,6 +21,7 @@
     #view3d {
       flex: 1;
       background-color: black;
+      margin-bottom: -29px;
     }
 
     #sidebar {


### PR DESCRIPTION
Removes an extra space below the play bar, fixes #3. See example:
https://lukicdarkoo.github.io/webots-example-visual-tracking/#visual_tracking

Note that this is a temporary fix and that the changes should be made in `webots.js`. 

