### PR TITLE
Fall back to GH nick if real username is missing

### DIFF
--- a/wb_animation_action/utils/git.py
+++ b/wb_animation_action/utils/git.py
@@ -28,7 +28,7 @@ def _init():
     result = subprocess.run('git config --list | grep user.name', shell=True, check=False)
     if result.returncode != 0:
         email = '{}+{}@users.noreply.github.com'.format(user_info['id'], username)
-        subprocess.check_output(['git', 'config', '--global', 'user.name', user_info['name']])
+        subprocess.check_output(['git', 'config', '--global', 'user.name', user_info['name'] or username])
         subprocess.check_output(['git', 'config', '--global', 'user.email', email])
 
 


### PR DESCRIPTION
The `user_info['name']` points at the real name a user may or may not choose to configure on their GitHub account. In the latter case, this value is `None` and it made the subprocess crash with:

`TypeError: expected str, bytes or os.PathLike object, not NoneType`